### PR TITLE
added nohtml import

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -1,3 +1,35 @@
+<div markdown="1">
+  <sup>Using <a href="https://wangchujiang.com/#/app" target="_blank">my app</a> is also a way to <a href="https://wangchujiang.com/#/sponsor" target="_blank">support</a> me:</sup>
+  <br>
+    <a target="_blank" href="https://apps.apple.com/app/Vidwall/6747587746" title="Vidwall for macOS"><img align="center" alt="Vidwall" height="52" width="52" src="https://github.com/user-attachments/assets/7b5df70a-ed91-4d4b-85be-f00e60a09ce9"></a>
+    <a target="_blank" href="https://wangchujiang.com/mousio-hint/" title="Mousio Hint for macOS"><img align="center" alt="Mousio Hint" height="52" width="52" src="https://github.com/user-attachments/assets/3c0af128-0cef-44e5-a8db-4741dc5a6690"></a>
+    <a target="_blank" href="https://apps.apple.com/app/6746747327" title="Mousio for macOS"><img align="center" alt="Mousio" height="52" width="52" src="https://github.com/user-attachments/assets/9edf61ff-5a6c-4676-9cc2-8fd3c1ad0dfb"></a>
+    <a target="_blank" href="https://apps.apple.com/app/6745227444" title="Musicer for macOS"><img align="center" alt="Musicer" height="52" width="52" src="https://github.com/user-attachments/assets/b7abfba8-88ff-4c86-a125-43073d5aef22"></a>
+    <a target="_blank" href="https://apps.apple.com/app/6743841447" title="Audioer for macOS"><img align="center" alt="Audioer" height="52" width="52" src="https://github.com/user-attachments/assets/7a836865-8c90-4119-87bc-19e06a76c957"></a>
+    <a target="_blank" href="https://apps.apple.com/app/6744690194" title="FileSentinel for macOS"><img align="center" alt="FileSentinel" height="52" width="52" src="https://github.com/user-attachments/assets/28bce2cc-290e-45bf-9068-585ff6ecafe9"></a>
+    <a target="_blank" href="https://apps.apple.com/app/6743495172" title="FocusCursor for macOS"><img align="center" alt="FocusCursor" height="52" width="52" src="https://github.com/user-attachments/assets/d543668a-737b-4853-a6bb-eaa269e69836"></a>
+    <a target="_blank" href="https://apps.apple.com/app/6742680573" title="Videoer for macOS"><img align="center" alt="Videoer" height="52" width="52" src="https://github.com/user-attachments/assets/10ffb0f1-0625-40d6-93f1-2c2496592595"></a>
+    <a target="_blank" href="https://apps.apple.com/app/6740425504" title="KeyClicker for macOS"><img align="center" alt="KeyClicker" height="52" width="52" src="https://github.com/user-attachments/assets/5a19fcb9-cb81-4855-b4ea-31c604d9612a"></a>
+    <a target="_blank" href="https://apps.apple.com/app/6739052447" title="DayBar for macOS"><img align="center" alt="DayBar" height="52" width="52" src="https://github.com/user-attachments/assets/771b608d-594c-492d-8532-d9231e383f5b"></a>
+    <a target="_blank" href="https://apps.apple.com/app/6739444407" title="Iconed for macOS"><img align="center" alt="Iconed" height="52" width="52" src="https://github.com/user-attachments/assets/8a35dc7b-4faf-4e2a-9311-f66d6844a896"></a>
+    <a target="_blank" href="https://apps.apple.com/app/6737160756" title="RightMenu Master for macOS"><img align="center" alt="RightMenu Master" height="52" width="52" src="https://github.com/user-attachments/assets/39a76541-71bf-4de7-a01c-c62f0557dff5"></a>
+    <a target="_blank" href="https://apps.apple.com/app/6723903021" title="Paste Quick for macOS"><img align="center" alt="Quick RSS" height="52" width="52" src="https://github.com/user-attachments/assets/bdaad5b7-9810-44ce-8f17-8410864465d2"></a>
+    <a target="_blank" href="https://apps.apple.com/app/6670696072" title="Quick RSS for macOS/iOS"><img align="center" alt="Quick RSS" height="52" width="52" src="https://github.com/user-attachments/assets/374106b5-a448-4d1d-9ccb-b04b6bc681ed"></a>
+    <a target="_blank" href="https://apps.apple.com/app/6670167443" title="Web Serve for macOS"><img align="center" alt="Web Serve" height="52" width="52" src="https://github.com/user-attachments/assets/e1d9f76f-0f3d-4ba5-8a15-253ee173bb1c"></a>
+    <a target="_blank" href="https://apps.apple.com/app/6503953628" title="Copybook Generator for macOS/iOS"><img align="center" alt="Copybook Generator" height="52" width="52" src="https://github.com/jaywcjlove/jaywcjlove/assets/1680273/b90e42ff-158b-4534-82ca-5898fd0e8d73"></a>
+    <a target="_blank" href="https://apps.apple.com/app/6471227008" title="DevTutor for macOS/iOS"><img align="center" alt="DevTutor for SwiftUI" height="52" width="52" src="https://github.com/jaywcjlove/jaywcjlove/assets/1680273/f15c154d-0192-48eb-8e0e-9e245ffd974a"></a>
+    <a target="_blank" href="https://apps.apple.com/app/6479819388" title="RegexMate for macOS/iOS"><img align="center" alt="RegexMate" height="52" width="52" src="https://github.com/jaywcjlove/jaywcjlove/assets/1680273/aabe5aa9-9a96-4390-8bed-c3e4023d0dea"></a>
+    <a target="_blank" href="https://apps.apple.com/app/6479194014" title="Time Passage for macOS/iOS"><img align="center" alt="Time Passage" height="52" width="52" src="https://github.com/jaywcjlove/time-passage/assets/1680273/6f30e429-e6f3-4dbe-9921-a5effe2a05e9"></a>
+    <a target="_blank" href="https://apps.apple.com/app/6478772538" title="IconizeFolder for macOS"><img align="center" alt="Iconize Folder" height="52" width="52" src="https://github.com/jaywcjlove/jaywcjlove/assets/1680273/fa9d8b9c-1e51-4ded-877c-fa5b21c47220"></a>
+    <a target="_blank" href="https://apps.apple.com/app/6478511402" title="Textsound Saver for macOS/iOS"><img align="center" alt="Textsound Saver" height="52" width="52" src="https://github.com/jaywcjlove/jaywcjlove/assets/1680273/0595e842-980b-4574-8891-a8ba853a08be"></a>
+    <a target="_blank" href="https://apps.apple.com/app/6476924627" title="Create Custom Symbols for macOS"><img align="center" alt="Create Custom Symbols" height="52" width="52" src="https://github.com/jaywcjlove/jaywcjlove/assets/1680273/8cd022ce-a3f1-4e89-b7c6-6fbd0d4db77c"></a>
+    <a target="_blank" href="https://apps.apple.com/app/6476452351" title="DevHub for macOS"><img align="center" alt="DevHub" height="52" width="52" src="https://github.com/user-attachments/assets/4a44a4fd-67ce-430b-af0a-72f18feaa47d"></a>
+    <a target="_blank" href="https://apps.apple.com/app/6476400184" title="Resume Revise for macOS"><img align="center" alt="Resume Revise" height="52" width="52" src="https://github.com/jaywcjlove/jaywcjlove/assets/1680273/c9954a20-1905-48de-bdf8-d71837974aa2"></a>
+    <a target="_blank" href="https://apps.apple.com/app/6472593276" title="Palette Genius for macOS"><img align="center" alt="Palette Genius" height="52" width="52" src="https://github.com/jaywcjlove/jaywcjlove/assets/1680273/27340413-d355-45b2-8f6f-6ac37682d957"></a>
+    <a target="_blank" href="https://apps.apple.com/app/6470879005" title="Symbol Scribe for macOS"><img align="center" alt="Symbol Scribe" height="52" width="52" src="https://github.com/jaywcjlove/jaywcjlove/assets/1680273/c7249f05-fa70-4def-a1e9-571d5f171fc9"></a>
+</div>
+<hr>
+
 <!--rehype:ignore:start-->
 React Markdown Preview
 ===

--- a/core/nohtml.d.ts
+++ b/core/nohtml.d.ts
@@ -1,0 +1,7 @@
+declare module '@uiw/react-markdown-preview/nohtml' {
+  import React from 'react';
+  import { MarkdownPreviewProps, MarkdownPreviewRef } from '@uiw/react-markdown-preview/lib/Props';
+  export * from '@uiw/react-markdown-preview/lib/Props';
+  const _default: React.ForwardRefExoticComponent<MarkdownPreviewProps & React.RefAttributes<MarkdownPreviewRef>>;
+  export default _default;
+}

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uiw/react-markdown-preview",
-  "version": "5.1.4",
+  "version": "5.1.5",
   "description": "React component preview markdown text in web browser. The minimal amount of CSS to replicate the GitHub Markdown style.",
   "homepage": "https://uiwjs.github.io/react-markdown-preview",
   "funding": "https://jaywcjlove.github.io/#/sponsor",

--- a/core/package.json
+++ b/core/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "@babel/runtime": "^7.17.2",
     "@uiw/copy-to-clipboard": "~1.0.12",
-    "react-markdown": "~9.0.1",
+    "react-markdown": "~9.1.0",
     "rehype-attr": "~3.0.1",
     "rehype-autolink-headings": "~7.1.0",
     "rehype-ignore": "^2.0.0",

--- a/core/package.json
+++ b/core/package.json
@@ -58,7 +58,7 @@
     "@babel/runtime": "^7.17.2",
     "@uiw/copy-to-clipboard": "~1.0.12",
     "react-markdown": "~9.1.0",
-    "rehype-attr": "~3.0.1",
+    "rehype-attr": "~4.0.0",
     "rehype-autolink-headings": "~7.1.0",
     "rehype-ignore": "^2.0.0",
     "rehype-prism-plus": "2.0.0",

--- a/core/package.json
+++ b/core/package.json
@@ -19,6 +19,11 @@
       "import": "./esm/nohighlight.js",
       "types": "./lib/nohighlight.d.ts",
       "require": "./lib/nohighlight.js"
+    },
+    "./nohtml": {
+      "import": "./esm/nohtml.js",
+      "types": "./lib/nohtml.d.ts",
+      "require": "./lib/nohtml.js"
     }
   },
   "scripts": {
@@ -40,6 +45,7 @@
     "dist",
     "lib",
     "esm",
+    "nohtml.d.ts",
     "nohighlight.d.ts",
     "markdown.css",
     "src/**/*.{ts,tsx,less}"

--- a/core/src/nohighlight.tsx
+++ b/core/src/nohighlight.tsx
@@ -3,7 +3,6 @@ import MarkdownPreview from './preview';
 import { type PluggableList } from 'unified';
 import rehypeRewrite from 'rehype-rewrite';
 import rehypeAttrs from 'rehype-attr';
-import rehypeRaw from 'rehype-raw';
 import { reservedMeta } from './plugins/reservedMeta';
 import { retrieveMeta } from './plugins/retrieveMeta';
 import { rehypeRewriteHandle, defaultRehypePlugins } from './rehypePlugins';
@@ -14,7 +13,6 @@ export * from './Props';
 export default React.forwardRef<MarkdownPreviewRef, MarkdownPreviewProps>((props, ref) => {
   const rehypePlugins: PluggableList = [
     reservedMeta,
-    rehypeRaw,
     retrieveMeta,
     ...defaultRehypePlugins,
     [rehypeRewrite, { rewrite: rehypeRewriteHandle(props.disableCopy ?? false, props.rehypeRewrite) }],

--- a/core/src/nohtml.tsx
+++ b/core/src/nohtml.tsx
@@ -3,7 +3,6 @@ import MarkdownPreview from './preview';
 import { type PluggableList } from 'unified';
 import rehypeRewrite from 'rehype-rewrite';
 import rehypeAttrs from 'rehype-attr';
-import rehypeRaw from 'rehype-raw';
 import { reservedMeta } from './plugins/reservedMeta';
 import { retrieveMeta } from './plugins/retrieveMeta';
 import { rehypeRewriteHandle, defaultRehypePlugins } from './rehypePlugins';
@@ -14,7 +13,6 @@ export * from './Props';
 export default React.forwardRef<MarkdownPreviewRef, MarkdownPreviewProps>((props, ref) => {
   const rehypePlugins: PluggableList = [
     reservedMeta,
-    rehypeRaw,
     retrieveMeta,
     ...defaultRehypePlugins,
     [rehypeRewrite, { rewrite: rehypeRewriteHandle(props.disableCopy ?? false, props.rehypeRewrite) }],

--- a/core/src/preview.tsx
+++ b/core/src/preview.tsx
@@ -43,7 +43,7 @@ export default React.forwardRef<MarkdownPreviewRef, MarkdownPreviewProps>((props
       return /^[A-Za-z0-9]+$/.test(element.tagName);
     },
   };
-  if (skipHtml) {
+  if (!skipHtml) {
     rehypePlugins.push(raw);
   }
   const remarkPlugins = [remarkAlert, ...(other.remarkPlugins || []), gfm];
@@ -53,7 +53,7 @@ export default React.forwardRef<MarkdownPreviewRef, MarkdownPreviewProps>((props
       <ReactMarkdown
         {...customProps}
         {...other}
-        skipHtml={skipHtml}
+        skipHtml={!skipHtml}
         urlTransform={urlTransform || defaultUrlTransform}
         rehypePlugins={pluginsFilter ? pluginsFilter('rehype', rehypePlugins) : rehypePlugins}
         remarkPlugins={pluginsFilter ? pluginsFilter('remark', remarkPlugins) : remarkPlugins}

--- a/core/src/preview.tsx
+++ b/core/src/preview.tsx
@@ -2,7 +2,6 @@ import React, { useImperativeHandle } from 'react';
 import ReactMarkdown, { type UrlTransform } from 'react-markdown';
 import { type PluggableList } from 'unified';
 import gfm from 'remark-gfm';
-import raw from 'rehype-raw';
 import { remarkAlert } from 'remark-github-blockquote-alert';
 import { useCopied } from './plugins/useCopied';
 import { type MarkdownPreviewProps, type MarkdownPreviewRef } from './Props';
@@ -43,9 +42,6 @@ export default React.forwardRef<MarkdownPreviewRef, MarkdownPreviewProps>((props
       return /^[A-Za-z0-9]+$/.test(element.tagName);
     },
   };
-  if (!skipHtml) {
-    rehypePlugins.push(raw);
-  }
   const remarkPlugins = [remarkAlert, ...(other.remarkPlugins || []), gfm];
   const wrapperProps = { ...warpperElement, ...wrapperElement };
   return (

--- a/examples/#269/package.json
+++ b/examples/#269/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/269",
-  "version": "5.1.4",
+  "version": "5.1.5",
   "private": true,
   "scripts": {
     "build": "kkt build",

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
-  "version": "5.1.4",
+  "version": "5.1.5",
   "packages": ["core", "examples/**", "website"]
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "husky": "~9.0.0",
     "prettier": "^3.0.0",
     "pretty-quick": "~4.0.0",
-    "lerna": "^8.0.0",
+    "lerna": "8.0.0",
     "react": "~18.2.0",
     "react-dom": "~18.2.0",
     "react-test-renderer": "~18.2.0",

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "website",
-  "version": "5.1.4",
+  "version": "5.1.5",
   "private": true,
   "scripts": {
     "build": "kkt build",


### PR DESCRIPTION
skipHTML prop still imported rehypeRaw. It ends up hiking my JS bundle by 200kb because of parse5 (rehypeRaw).

First I tried to add some lazy loading, but the solution was very ugly with `useEffect` and async function. 

Then decided to create a new entry-point just like nohighlight, but this time its nohtml
it has no highlighting and no html

